### PR TITLE
[build] skip jacocoTestReport

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -16,5 +16,9 @@ git reset --hard
 # aren't run directly in buddybuild.
 ./gradlew findbugs
 
-./gradlew jacocoTestReport
-bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+# skip jacocoTestReport because we don't have adjust token and build fail on release variant
+#./gradlew jacocoTestReport
+
+
+# skip CODECOV
+#bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN


### PR DESCRIPTION
The jacocoTestReport task is running as buddybuild post build script. Forced run in every variant even testing is disabled. Skip it for now, and re-enable it if we're close enough to release.