### PR TITLE
ui: Do not show main FAB in BrowserFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
@@ -123,7 +123,7 @@ public class MainMediator {
                 toggleFloatingButtons(View.VISIBLE, View.GONE, View.VISIBLE);
             }
             if (BrowserFragment.FRAGMENT_TAG.equals(top.getTag())) {
-                toggleFloatingButtons(View.VISIBLE, View.VISIBLE, View.VISIBLE);
+                toggleFloatingButtons(View.GONE, View.GONE, View.GONE);
             }
         }
     }


### PR DESCRIPTION
since we duplicate FAB in two places, we should not show main FAB in
BrowserFragement - it already has its own FAB.

this commit will fix #119