### PR TITLE
Fix svg to vector-drawable bug - convert curve to line

### DIFF
--- a/app/src/main/res/drawable/action_search.xml
+++ b/app/src/main/res/drawable/action_search.xml
@@ -1,24 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-
-    <group>
-        <path
-            android:fillColor="#BCEF2C"
-            android:fillAlpha="0"
-            android:fillType="evenOdd"
-            android:strokeAlpha="0"
-            android:strokeWidth="1"
-            android:pathData="M 0 0 H 24 V 24 H 0 V 0 Z" />
-        <path
-            android:fillColor="#272727"
-            android:fillType="evenOdd"
-            android:pathData="M9.5 15A5.506 5.506 0 0 1 4 9.5C4 6.467 6.468 4 9.5 4S15 6.467 15 9.5 12.532 15
-9.5 15m11.957 5.043l-6.002-6.002A7.45 7.45 0 0 0 17 9.5C17 5.364 13.636 2 9.5
-2S2 5.364 2 9.5 5.364 17 9.5 17a7.45 7.45 0 0 0 4.541-1.545l6.002 6.002a.997
-.997 0 0 0 1.414 0 .999 .999 0 0 0 0-1.414" />
-    </group>
+    <path
+        android:fillColor="#272727"
+        android:pathData="M9.5,15C6.464,14.997 4.003,12.536 4,9.5 4,6.467 6.468,4 9.5,4 12.532,4 15,6.467 15,9.5 15,12.533 12.532,15 9.5,15m11.957,5.043 l-6.002,-6.002C16.457,12.739 17,11.143 17,9.5 17,5.364 13.636,2 9.5,2 5.364,2 2,5.364 2,9.5 2,13.636 5.364,17 9.5,17c1.643,-0 3.239,-0.543 4.541,-1.545l6.002,6.002c0.39,0.392 1.024,0.392 1.414,0 0.391,-0.39 0.391,-1.024 0,-1.414" />
 </vector>


### PR DESCRIPTION
Android L dues not fully support vector-drawable with curve path but only line path.
However, convert all curve to line seems not so easy for Engineer. Need to figure out solution, otherwise, we fallback to png solution.