### PR TITLE
Implement PanelFragment as a transaction to close ListPanelDialog from childrens

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/DownloadFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/DownloadFragment.java
@@ -17,7 +17,7 @@ import android.view.ViewGroup;
 import org.mozilla.focus.R;
 import org.mozilla.focus.widget.DownloadListAdapter;
 
-public class DownloadFragment extends Fragment {
+public class DownloadFragment extends PanelFragment {
 
     private RecyclerView recyclerView;
     private DownloadListAdapter mDownloadListAdapter;

--- a/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
@@ -24,6 +24,7 @@ public class ListPanelDialog extends DialogFragment {
     public final static int TYPE_DOWNLOAD = 1;
     public final static int TYPE_HISTORY = 2;
     public final static int TYPE_SCREENSHOTS = 3;
+    private static final int UNUSED_REQUEST_CODE = -1;
 
     private NestedScrollView scrollView;
     private static final String TYPE = "TYPE";
@@ -126,19 +127,22 @@ public class ListPanelDialog extends DialogFragment {
 
     private void showDownload() {
         setSelectedItem(TYPE_DOWNLOAD);
-        DownloadFragment downloadFragment = DownloadFragment.newInstance();
-        getChildFragmentManager().beginTransaction().replace(R.id.main_content, downloadFragment).commit();
+        showPanelFragment(DownloadFragment.newInstance());
     }
 
     private void showHistory() {
         setSelectedItem(TYPE_HISTORY);
-        BrowsingHistoryFragment browsingHistoryFragment = BrowsingHistoryFragment.newInstance();
-        getChildFragmentManager().beginTransaction().replace(R.id.main_content, browsingHistoryFragment).commit();
+        showPanelFragment(BrowsingHistoryFragment.newInstance());
     }
 
     private void showScreenshots() {
         setSelectedItem(TYPE_SCREENSHOTS);
-        getChildFragmentManager().beginTransaction().replace(R.id.main_content, new Fragment()).commit();
+        showPanelFragment(new PanelFragment());
+    }
+
+    private void showPanelFragment(PanelFragment panelFragment) {
+        panelFragment.setTargetFragment(this, UNUSED_REQUEST_CODE);
+        getChildFragmentManager().beginTransaction().replace(R.id.main_content, panelFragment).commit();
     }
 
     private void toggleSelectedItem() {

--- a/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
@@ -1,0 +1,21 @@
+package org.mozilla.focus.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+
+public class PanelFragment extends Fragment {
+
+    protected void closePanel() {
+        ((ListPanelDialog)getTargetFragment()).dismiss();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if( ! (getTargetFragment() instanceof ListPanelDialog) ) {
+            throw new RuntimeException("PanelFragments should have its Target Fragment set to an instance of ListPanelDialog");
+        }
+    }
+
+}

--- a/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryFragment.java
+++ b/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryFragment.java
@@ -1,7 +1,6 @@
 package org.mozilla.focus.history;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -10,9 +9,10 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.fragment.PanelFragment;
 
 
-public class BrowsingHistoryFragment extends Fragment implements View.OnClickListener, HistoryItemAdapter.EmptyListener {
+public class BrowsingHistoryFragment extends PanelFragment implements View.OnClickListener, HistoryItemAdapter.HistoryListener {
 
     private Button mBtnClearHistory;
     private RecyclerView mContainerRecyclerView;
@@ -65,5 +65,10 @@ public class BrowsingHistoryFragment extends Fragment implements View.OnClickLis
             mContainerRecyclerView.setVisibility(View.VISIBLE);
             mContainerEmptyView.setVisibility(View.GONE);
         }
+    }
+
+    @Override
+    public void onItemClicked() {
+        closePanel();
     }
 }

--- a/app/src/main/java/org/mozilla/focus/history/HistoryItemAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/history/HistoryItemAdapter.java
@@ -1,6 +1,5 @@
 package org.mozilla.focus.history;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -41,20 +40,21 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     private RecyclerView mRecyclerView;
     private LinearLayoutManager mLayoutManager;
     private Context mContext;
-    private EmptyListener mEmptyListener;
+    private HistoryListener mHistoryListener;
     private boolean mIsInitialQuery;
     private boolean mIsLoading;
     private boolean mIsLastPage;
     private int mCurrentCount;
 
-    public interface EmptyListener {
+    public interface HistoryListener {
         void onEmpty(boolean flag);
+        void onItemClicked();
     }
 
-    public HistoryItemAdapter(RecyclerView recyclerView, Context context, EmptyListener emptyListener, LinearLayoutManager layoutManager) {
+    public HistoryItemAdapter(RecyclerView recyclerView, Context context, HistoryListener historyListener, LinearLayoutManager layoutManager) {
         mRecyclerView = recyclerView;
         mContext = context;
-        mEmptyListener = emptyListener;
+        mHistoryListener = historyListener;
         mLayoutManager = layoutManager;
         mIsInitialQuery = true;
         loadMoreItems();
@@ -152,6 +152,7 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
                 intent.setAction(Intent.ACTION_VIEW);
                 intent.setData(Uri.parse(((Site) item).getUrl()));
                 mContext.startActivity(intent);
+                mHistoryListener.onItemClicked();
             }
         }
     }
@@ -226,8 +227,8 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     }
 
     private void notifyEmptyListener(boolean flag) {
-        if (mEmptyListener != null) {
-            mEmptyListener.onEmpty(flag);
+        if (mHistoryListener != null) {
+            mHistoryListener.onEmpty(flag);
         }
     }
 


### PR DESCRIPTION
Fixes #256 

We need an interface to provide children fragments of ListPanelDialog to close the ListPanelDialog when necessary. We ensure that all childrens are instance of PanelFragment, and provide a closePanel() for PanelFragment instances.

BrowsingHistoryFragment is one that needs this and is setup to close panel with the aforementioned methodology in this commit.