### PR TITLE
Avoid using setTargetFragment() since it is crashing when we're resuming

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
@@ -138,7 +138,6 @@ public class ListPanelDialog extends DialogFragment {
     }
 
     private void showPanelFragment(PanelFragment panelFragment) {
-        panelFragment.setTargetFragment(this, UNUSED_REQUEST_CODE);
         getChildFragmentManager().beginTransaction().replace(R.id.main_content, panelFragment).commit();
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
@@ -7,14 +7,14 @@ import android.support.v4.app.Fragment;
 public class PanelFragment extends Fragment {
 
     protected void closePanel() {
-        ((ListPanelDialog)getTargetFragment()).dismiss();
+        ((ListPanelDialog)getParentFragment()).dismiss();
     }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if( ! (getTargetFragment() instanceof ListPanelDialog) ) {
-            throw new RuntimeException("PanelFragments should have its Target Fragment set to an instance of ListPanelDialog");
+        if( ! (getParentFragment() instanceof ListPanelDialog) ) {
+            throw new RuntimeException("PanelFragments needs its parent to be an instance of ListPanelDialog");
         }
     }
 


### PR DESCRIPTION
setTargetFragment() is discouraged

Ref:
https://stackoverflow.com/questions/29714476/fragment-no-longer-exists-for-key-androidtarget-state
https://issuetracker.google.com/issues/36969568

Fixes #258