### PR TITLE
Restore webview state and filter out unwanted onPageFinished()

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -36,6 +36,7 @@ import java.util.Map;
     private IWebView.Callback callback;
     private boolean errorReceived;
     private Context context;
+    private boolean hasPageStarted = false;
 
     public FocusWebViewClient(Context context) {
         super(context);
@@ -79,6 +80,7 @@ import java.util.Map;
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        hasPageStarted = true;
         if (errorReceived) {
             // When dealing with error pages, webkit sometimes sends onPageStarted()
             // without a matching onPageFinished(). We hack around that by using
@@ -97,7 +99,12 @@ import java.util.Map;
 
     @Override
     public void onPageFinished(WebView view, final String url) {
-        if (callback != null) {
+        // FIXME: 9/11/17
+        // There are some onPageFinished that are fired due to Webview.restoreState()
+        // As a quick fix we filtered these onPageFinished out since they are having
+        // some properties such as: the getTitle() returned here is incomplete.
+        // We'll need to deep dive into these when we have time.
+        if (callback != null && hasPageStarted) {
             callback.onPageFinished(view.getCertificate() != null);
             // The URL which is supplied in onPageFinished() could be fake (see #301), but webview's
             // URL is always correct _except_ for error pages

--- a/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
@@ -88,10 +88,6 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
 
     @Override
     public void restoreWebviewState(Bundle savedInstanceState) {
-        /*
-            Focus is trying to restore the not fully loaded page
-            However, it is sending extra onPageFinished events that confuses us.
-            Let's first comment out this.
         // We need to have a different method name because restoreState() returns
         // a WebBackForwardList, and we can't overload with different return types:
         final WebBackForwardList backForwardList = restoreState(savedInstanceState);
@@ -116,7 +112,6 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
         } else {
             loadUrl(desiredURL);
         }
-        */
     }
 
     @Override


### PR DESCRIPTION
This reverts commit d4ee9ac71f71ce660aa1bc48bd396193e1d1ebe6 and seeks to find an alternative quick fix which was solved but backed reverted in #632 
Fixes #700 