### PR TITLE
settings: always disable preference if there is no SD-card

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/StorageUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StorageUtils.java
@@ -28,7 +28,7 @@ public class StorageUtils {
      * @return app-owned-directory on removable storage
      * @throws NoRemovableStorageException if there is no removable storage to use.
      */
-    private static File getAppMediaDirOnRemovableStorage(@NonNull Context ctx)
+    public static File getAppMediaDirOnRemovableStorage(@NonNull Context ctx)
             throws NoRemovableStorageException {
 
         final File media = getFirstRemovableMedia(ctx);


### PR DESCRIPTION
According to design spec, if there is no removable storage to use, its
preference should always be disbaled and display text 'save to sd card'

to fix #461