### PR TITLE
clear WebView callback in onDestroyView

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -50,8 +50,11 @@ public abstract class WebFragment extends LocaleAwareFragment {
         final View view = inflateLayout(inflater, container, savedInstanceState);
 
         webView = (IWebView) view.findViewById(R.id.webview);
-        isWebViewAvailable = true;
-        webView.setCallback(createCallback());
+        if (webView != null) {
+            isWebViewAvailable = true;
+            webView.setCallback(createCallback());
+        }
+
 
         return view;
     }
@@ -110,24 +113,20 @@ public abstract class WebFragment extends LocaleAwareFragment {
     }
 
     @Override
-    public void onDestroy() {
+    public void onDestroyView() {
+        isWebViewAvailable = false;
+
         if (webView != null) {
+            // If Fragment is detached from Activity but not be destroyed, onSaveInstanceState won't be
+            // called. In this case we must store webView-state manually, to retain browsing history.
+            webViewState = new Bundle();
+            webView.onSaveInstanceState(webViewState);
+
+            // clear callback in case of callback-instance will touch view in onPageFinished
             webView.setCallback(null);
             webView.destroy();
             webView = null;
         }
-
-        super.onDestroy();
-    }
-
-    @Override
-    public void onDestroyView() {
-        isWebViewAvailable = false;
-
-        // If Fragment is detached from Activity but not be destroyed, onSaveInstanceState won't be
-        // called. In this case we must store webView-state manually, to retain browsing history.
-        webViewState = new Bundle();
-        webView.onSaveInstanceState(webViewState);
         super.onDestroyView();
     }
 


### PR DESCRIPTION
We set webview callback in `onCreateView`, now clear the callback in
`onDestroyView`. `onDestroy` might not be called if the fragment just be
detached from activity.

This patch suppose to fix #423 #424