### PR TITLE
settings: fix flag value

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/DataSavingPathPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DataSavingPathPreference.java
@@ -72,6 +72,8 @@ public class DataSavingPathPreference extends ListPreference {
     private void pingRemovableStorage() {
         try {
             StorageUtils.getAppMediaDirOnRemovableStorage(getContext());
+            // no exception
+            hasRemovableStorage = true;
         } catch (NoRemovableStorageException e) {
             hasRemovableStorage = false;
         }


### PR DESCRIPTION
the value should be set to true if removable storage exists