### PR TITLE
Enable image loading for about/error page and disable it after page loaded if needed.

### DIFF
--- a/app/src/main/res/raw/about.html
+++ b/app/src/main/res/raw/about.html
@@ -11,5 +11,6 @@
 <img src="%wordmark%" id="wordmark"/>
 <p class="subtitle">%about-version%</p>
 %about-content%
+<input type="hidden" id="mozillaAboutPage">
 </body>
 </html>

--- a/app/src/webkit/java/org/mozilla/focus/webkit/ErrorPage.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/ErrorPage.java
@@ -62,6 +62,7 @@ public class ErrorPage {
         // We could load the raw html file directly into the webview using a file:///android_res/
         // URI - however we'd then need to do some JS hacking to do our String substitutions. Moreover
         // we'd have to deal with the mixed-content issues detailed above in that case.
+        webView.getSettings().setLoadsImagesAutomatically(true);
         webView.loadDataWithBaseURL(desiredURL, errorPage, "text/html", "UTF8", desiredURL);
     }
 }

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -266,6 +266,7 @@ import java.util.Map;
         final String data = HtmlLoader.loadResourceFile(webView.getContext(), R.raw.about, substitutionMap);
         // We use a file:/// base URL so that we have the right origin to load file:/// css and
         // image resources.
+        webView.getSettings().setLoadsImagesAutomatically(true);
         webView.loadDataWithBaseURL(aboutURI, data, "text/html", "UTF-8", null);
     }
 


### PR DESCRIPTION
Closes #736 