### PR TITLE
download: cancel download if storage is not mounted

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -25,7 +25,6 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
@@ -554,6 +553,14 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         // But we might move downloaded file to another directory.
         // So, for now we always save file to DIRECTORY_DOWNLOADS
         final String dir = Environment.DIRECTORY_DOWNLOADS;
+
+        if (!Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
+            Toast.makeText(getContext(),
+                    R.string.message_storage_unavailable_cancel_download,
+                    Toast.LENGTH_LONG)
+                    .show();
+            return;
+        }
 
         // block non-http/https download links
         if(!URLUtil.isNetworkUrl(download.getUrl())) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="message_enable_block_image">Now blocking images</string>
     <string name="message_disable_block_image">Now showing images</string>
     <string name="message_clear_cache_fail">Unable to clear cache</string>
+    <string name="message_storage_unavailable_cancel_download">Storage is unavailable, download canceled</string>
 
     <!-- Message indicate how much cache file cause disk storage was cleared.
         Argument 1 is the amount, i.e. 15.0 MB cache cleared -->


### PR DESCRIPTION
We want to save file to primary external storage. If phone shares its
primary external storage to PC when usb connected(Mito phone did this),
then the storage is not available.

this should fix #483