### PR TITLE
Avoid calling Activity.onBackPressed() when not allowed

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -656,6 +656,9 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
     @Override
     public void onBackPressed() {
+        if (!safeForFragmentTransactions) {
+            return;
+        }
         if (this.mediator.handleBackKey()) {
             return;
         }


### PR DESCRIPTION
Fixes #469 