### PR TITLE
Use Toast to instead of Snackbar

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -747,8 +747,8 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         if (TextUtils.isEmpty(msg)) {
             return;
         }
-        final View container = findViewById(R.id.container);
-        Snackbar.make(container, msg, Snackbar.LENGTH_SHORT).show();
+
+        Toast.makeText(this, msg, Toast.LENGTH_SHORT).show();
     }
 
     private void asyncInitialize() {


### PR DESCRIPTION
In current spec, if a message has no action alone with it, we just show
the message in Toast.