### PR TITLE
fix crash of NPE

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -113,7 +113,7 @@ public abstract class WebFragment extends LocaleAwareFragment {
 
         // FIXME: add debug message for #857
         if (!AppConstants.isReleaseBuild()) {
-            webViewState.putInt(WebkitView.KEY_DEBUG, 1);
+            outState.putInt(WebkitView.KEY_DEBUG, 1);
         }
         super.onSaveInstanceState(outState);
     }


### PR DESCRIPTION
should write debug message to parameter outState, but not instance
field, since the field might be null.

to fix #935