### PR TITLE
Implement tryLoadMore in PanelFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/DownloadsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/DownloadsFragment.java
@@ -75,6 +75,11 @@ public class DownloadsFragment extends PanelFragment implements DownloadInfoMana
     }
 
     @Override
+    public void tryLoadMore() {
+        // TODO: 2017/9/26
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         LocalBroadcastManager.getInstance(getContext()).registerReceiver(mInsertReceiver

--- a/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/ListPanelDialog.java
@@ -71,6 +71,19 @@ public class ListPanelDialog extends DialogFragment {
                              Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_listpanel_dialog, container, false);
         scrollView = (NestedScrollView) v.findViewById(R.id.main_content);
+        scrollView.setOnScrollChangeListener(new NestedScrollView.OnScrollChangeListener() {
+
+            @Override
+            public void onScrollChange(NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                final int halfPageSize = v.getMeasuredHeight() / 2;
+                if ( scrollY > oldScrollY && v.getMeasuredHeight() - scrollY < halfPageSize ) {
+                    PanelFragment pf = (PanelFragment) getChildFragmentManager().findFragmentById(R.id.main_content);
+                    if ( pf != null && pf.isVisible() ) {
+                        pf.tryLoadMore();
+                    }
+                }
+            }
+        });
         BottomSheetBehavior bottomSheetBehavior = BottomSheetBehavior.from(scrollView);
         bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
         bottomSheetBehavior.setBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {

--- a/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/PanelFragment.java
@@ -9,7 +9,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 
-public class PanelFragment extends Fragment {
+public abstract class PanelFragment extends Fragment {
 
     protected void closePanel() {
         ((ListPanelDialog)getParentFragment()).dismiss();
@@ -22,5 +22,7 @@ public class PanelFragment extends Fragment {
             throw new RuntimeException("PanelFragments needs its parent to be an instance of ListPanelDialog");
         }
     }
+
+    public abstract void tryLoadMore();
 
 }

--- a/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryFragment.java
+++ b/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryFragment.java
@@ -53,7 +53,7 @@ public class BrowsingHistoryFragment extends PanelFragment implements View.OnCli
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
-        mAdapter = new HistoryItemAdapter(mRecyclerView, getActivity(), this, layoutManager);
+        mAdapter = new HistoryItemAdapter(mRecyclerView, getActivity(), this);
         mRecyclerView.setAdapter(mAdapter);
         mRecyclerView.setLayoutManager(layoutManager);
     }
@@ -106,5 +106,10 @@ public class BrowsingHistoryFragment extends PanelFragment implements View.OnCli
     @Override
     public void onItemClicked() {
         closePanel();
+    }
+
+    @Override
+    public void tryLoadMore() {
+        mAdapter.tryLoadMore();
     }
 }

--- a/app/src/main/java/org/mozilla/focus/history/HistoryItemAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/history/HistoryItemAdapter.java
@@ -44,7 +44,6 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
     private List mItems = new ArrayList();
     private RecyclerView mRecyclerView;
-    private LinearLayoutManager mLayoutManager;
     private Context mContext;
     private HistoryListener mHistoryListener;
     private boolean mIsInitialQuery;
@@ -57,27 +56,19 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
         void onItemClicked();
     }
 
-    public HistoryItemAdapter(RecyclerView recyclerView, Context context, HistoryListener historyListener, LinearLayoutManager layoutManager) {
+    public HistoryItemAdapter(RecyclerView recyclerView, Context context, HistoryListener historyListener) {
         mRecyclerView = recyclerView;
         mContext = context;
         mHistoryListener = historyListener;
-        mLayoutManager = layoutManager;
         mIsInitialQuery = true;
         notifyStatusListener(BrowsingHistoryFragment.ON_OPENING);
         loadMoreItems();
-        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                final int visibleItemCount = mLayoutManager.getChildCount();
-                final int totalItemCount = mLayoutManager.getItemCount();
-                final int firstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
-                if (!mIsLoading && !mIsLastPage) {
-                    if ((visibleItemCount + firstVisibleItemPosition) >= totalItemCount && firstVisibleItemPosition >= 0) {
-                        loadMoreItems();
-                    }
-                }
-            }
-        });
+    }
+
+    public void tryLoadMore() {
+        if (!mIsLoading && !mIsLastPage) {
+            loadMoreItems();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotGridFragment.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotGridFragment.java
@@ -93,4 +93,9 @@ public class ScreenshotGridFragment extends PanelFragment implements ScreenshotI
             mAdapter.onItemDelete(id);
         }
     }
+
+    @Override
+    public void tryLoadMore() {
+        mAdapter.tryLoadMore();
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotItemAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotItemAdapter.java
@@ -61,19 +61,12 @@ public class ScreenshotItemAdapter extends RecyclerView.Adapter<RecyclerView.Vie
         mIsInitialQuery = true;
         notifyStatusListener(ScreenshotGridFragment.ON_OPENING);
         loadMoreItems();
-        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                final int visibleItemCount = mLayoutManager.getChildCount();
-                final int totalItemCount = mLayoutManager.getItemCount();
-                final int firstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
-                if (!mIsLoading && !mIsLastPage) {
-                    if ((visibleItemCount + firstVisibleItemPosition) >= totalItemCount && firstVisibleItemPosition >= 0) {
-                        loadMoreItems();
-                    }
-                }
-            }
-        });
+    }
+
+    public void tryLoadMore() {
+        if (!mIsLoading && !mIsLastPage) {
+            loadMoreItems();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #344 

Recyclerview.onScrollListener does not scroll under current implementation.
Use PanelFragment implementation as a quick fix.