### PR TITLE
dev: only throws exception in dev-build

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -153,10 +153,10 @@ public abstract class WebFragment extends LocaleAwareFragment {
             if (UrlUtils.isUrl(url)) {
                 this.pendingUrl = null; // clear pending url
 
-                // in case of any unexpected path to here, to normalize URL in release build
-                final String target = AppConstants.isReleaseBuild() ? UrlUtils.normalize(url) : url;
+                // in case of any unexpected path to here, to normalize URL in beta/release build
+                final String target = AppConstants.isDevBuild() ? url: UrlUtils.normalize(url);
                 webView.loadUrl(target);
-            } else if (!AppConstants.isReleaseBuild()) {
+            } else if (AppConstants.isDevBuild()) {
                 // throw exception to highlight this issue, except release build.
                 throw new RuntimeException("trying to open a invalid url: " + url);
             }

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -116,10 +116,10 @@ import java.util.Map;
         view.getSettings().setLoadsImagesAutomatically(true);
         if (url == null) {
             // in case of null url, we won't crash app in release build
-            if (AppConstants.isReleaseBuild()) {
-                return super.shouldOverrideUrlLoading(view, "");
-            } else {
+            if (AppConstants.isDevBuild()) {
                 throw new RuntimeException("Got null url in FocsWebViewClient.shouldOverrideUrlLoading");
+            } else {
+                return super.shouldOverrideUrlLoading(view, "");
             }
         }
 


### PR DESCRIPTION
We are closing to release. To reduce crash log, now we only throws
Exception in dev-build to warn developers. And keep silent to other
people.