### PR TITLE
Don't update failing url when error page is being displayed

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -505,8 +505,12 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             }
 
             @Override
-            public void updateFailingUrl(String url) {
-                this.failingUrl = url;
+            public void updateFailingUrl(String url, boolean updateFromError) {
+                if( !updateFromError && !url.equals(failingUrl)) {
+                    failingUrl = null;
+                } else {
+                    this.failingUrl = url;
+                }
             }
         };
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
@@ -121,7 +121,7 @@ public class InfoFragment extends WebFragment {
             }
 
             @Override
-            public void updateFailingUrl(String url) {}
+            public void updateFailingUrl(String url, boolean updateFromError) {}
         };
     }
 

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -82,7 +82,7 @@ public interface IWebView {
                                    ValueCallback<Uri[]> filePathCallback,
                                    WebChromeClient.FileChooserParams fileChooserParams);
 
-        void updateFailingUrl(String url);
+        void updateFailingUrl(String url, boolean updateFromError);
     }
 
     interface FullscreenCallback {

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -83,7 +83,7 @@ import java.util.Map;
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
 
         if (callback != null) {
-            callback.updateFailingUrl(null);
+            callback.updateFailingUrl(url, false);
         }
 
         if (errorReceived) {
@@ -178,7 +178,7 @@ import java.util.Map;
         errorReceived = true;
 
         if (callback != null) {
-            callback.updateFailingUrl(failingUrl);
+            callback.updateFailingUrl(failingUrl, true);
         }
 
         // This is a hack: onReceivedError(WebView, WebResourceRequest, WebResourceError) is API 23+ only,

--- a/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
@@ -360,8 +360,8 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
         }
 
         @Override
-        public void updateFailingUrl(String url) {
-            this.callback.updateFailingUrl(url);
+        public void updateFailingUrl(String url, boolean updateFromError) {
+            this.callback.updateFailingUrl(url, updateFromError);
         }
     }
 


### PR DESCRIPTION
Fixes #1026 

Well this is assuming that failing url does not load correctly so it will always be redirected to our errorpage. An assumption that does not always hold but is fairly correct for the most of the time. Let's deal with the edge cases later.