### PR TITLE
Send RELOCATE_FINISH broadcast after we updated db

### DIFF
--- a/app/src/main/java/org/mozilla/focus/components/RelocateService.java
+++ b/app/src/main/java/org/mozilla/focus/components/RelocateService.java
@@ -152,7 +152,6 @@ public class RelocateService extends IntentService {
                 // downloaded file is moved, update database to reflect this changing
                 final DownloadInfoManager mgr = DownloadInfoManager.getInstance();
                 mgr.replacePath(downloadId, destFile.getAbsolutePath(), type);
-                broadcastRelocateFinished(rowId);
 
                 // removable-storage did not exist on app creation, but now it is back
                 // we moved download file to removable-storage, now we should inform user

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -18,6 +18,8 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
 
+import org.mozilla.focus.utils.Constants;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -248,6 +250,11 @@ public class DownloadInfoManager {
                             @Override
                             public void onUpdateComplete(int result) {
                                 notifyRowUpdated(mContext, rowId);
+                                final Intent broadcastIntent = new Intent(Constants.ACTION_NOTIFY_RELOCATE_FINISH);
+                                broadcastIntent.addCategory(Constants.CATEGORY_FILE_OPERATION);
+                                broadcastIntent.putExtra(Constants.EXTRA_ROW_ID, rowId);
+
+                                LocalBroadcastManager.getInstance(mContext).sendBroadcast(broadcastIntent);
                             }
                         });
                         break;


### PR DESCRIPTION
We're updating the rowId -> filePath mapping in replacePath()

This creates a race condition for queryByDownloadId -> updateByRowId vs Snackbar.show -> userClickAction

On Samsung, updateByRowId is usally slower.

Thus we should actually toast after we have finished the update.

BTW I should reuse the broadcast code... Let's fix it when we have time.